### PR TITLE
more stuff

### DIFF
--- a/functions/pr-autofill-description.sh
+++ b/functions/pr-autofill-description.sh
@@ -5,25 +5,65 @@ source "$HOME/dotfiles-local/functions/shared/show_spinner.sh"
 
 # Auto-fill PR description using Claude Code
 pr-autofill-description() {
+  # Declare all shared variables as local
+  local current_branch merge_target temp_file pr_number claude_pid diff_content word_count
+  local interrupted=false
+
+  # Check for required dependencies
+  check_dependencies() {
+    local missing_tools=()
+    command -v git >/dev/null || missing_tools+=("git")
+    command -v gh >/dev/null || missing_tools+=("gh")
+    command -v claude >/dev/null || missing_tools+=("claude")
+    command -v jq >/dev/null || missing_tools+=("jq")
+
+    if [ ${#missing_tools[@]} -gt 0 ]; then
+      echo "❌ Missing required tools: ${missing_tools[*]}"
+      echo "Please install the missing tools before running this script"
+      return 1
+    fi
+  }
+
+  # Global cleanup function
+  cleanup_all() {
+    [ -n "$claude_pid" ] && kill "$claude_pid" 2>/dev/null && wait "$claude_pid" 2>/dev/null
+    [ -n "$temp_file" ] && rm -f "$temp_file" "${temp_file}.clean" 2>/dev/null
+    tput cnorm 2>/dev/null  # Restore cursor
+  }
+
+  # Signal handler
+  handle_interrupt() {
+    echo ""
+    echo "Interrupted. Cleaning up..."
+    interrupted=true
+    cleanup_all
+  }
+
+  # Set up global traps
+  trap handle_interrupt INT TERM
+  trap cleanup_all EXIT
+
   validate_git_environment() {
     if ! git rev-parse --git-dir > /dev/null 2>&1; then
       echo "Error: Not in a git repository"
       return 1
     fi
 
-    current_branch=$(git branch --show-current)
-    if [ -z "$current_branch" ]; then
+    if ! current_branch=$(git branch --show-current 2>/dev/null) || [ -z "$current_branch" ]; then
       echo "Error: Could not determine current branch"
       return 1
     fi
   }
 
   determine_merge_target() {
-    merge_target=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+    if ! merge_target=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'); then
+      merge_target=""
+    fi
+
     if [ -z "$merge_target" ]; then
-      if git show-ref --verify --quiet refs/remotes/origin/main; then
+      if git show-ref --verify --quiet refs/remotes/origin/main 2>/dev/null; then
         merge_target="main"
-      elif git show-ref --verify --quiet refs/remotes/origin/master; then
+      elif git show-ref --verify --quiet refs/remotes/origin/master 2>/dev/null; then
         merge_target="master"
       else
         echo "Error: Could not determine merge target branch"
@@ -33,23 +73,23 @@ pr-autofill-description() {
   }
 
   generate_description_with_claude() {
-    local template_file="$HOME/dotfiles-local/templates/pr_description.md"
-    temp_file=$(mktemp)
-
-    # Set up trap to kill Claude process on Ctrl+C
-    cleanup_claude() {
-      if [ -n "$claude_pid" ] && kill -0 "$claude_pid" 2>/dev/null; then
-        echo ""
-        echo "Terminating Claude process..."
-        kill "$claude_pid" 2>/dev/null
-        wait "$claude_pid" 2>/dev/null
-      fi
-      rm -f "$temp_file"
-      tput cnorm  # Restore cursor
-      trap - INT  # Clear the trap
+    # Check if interrupted before starting
+    if [ "$interrupted" = true ]; then
       return 1
-    }
-    trap cleanup_claude INT
+    fi
+
+    local template_file="$HOME/dotfiles-local/templates/pr_description.md"
+    local claude_path
+
+    # Find claude binary
+    if command -v claude >/dev/null; then
+      claude_path="claude"
+    elif [ -x "/opt/homebrew/bin/claude" ]; then
+      claude_path="/opt/homebrew/bin/claude"
+    else
+      echo "❌ Could not find claude binary"
+      return 1
+    fi
 
     set +m
     (
@@ -61,30 +101,75 @@ pr-autofill-description() {
       echo ""
       echo "Here are the git changes:"
       echo ""
-      git diff "$merge_target"...HEAD
-    ) | /opt/homebrew/bin/claude -p "Hey! Can you help me fill out this PR description? Look at the changes and fill in the template with what's actually changing. Keep it casual and conversational - imagine you're explaining the changes to a teammate over coffee. No need to be super formal or use fancy words. Just explain what you did and why in a way that makes sense. Skip any corporate-speak or overly professional language. If something's a quick fix or cleanup, just say that. IMPORTANT: Return ONLY the filled template - no markdown code blocks, no 'Based on...' intro, no explanations. Just start with '# Summary' and fill in the template." > "$temp_file" 2>&1 &
+      if ! git diff "$merge_target"...HEAD 2>/dev/null; then
+        echo "Error: Could not generate git diff"
+        exit 1
+      fi
+    ) | "$claude_path" -p "Hey! Can you help me fill out this PR description? Look at the changes and fill in the template with what's actually changing. Keep it casual and conversational - imagine you're explaining the changes to a teammate over coffee. No need to be super formal or use fancy words. Just explain what you did and why in a way that makes sense. Skip any corporate-speak or overly professional language. If something's a quick fix or cleanup, just say that. IMPORTANT: Return ONLY the filled template - no markdown code blocks, no 'Based on...' intro, no explanations. Just start with '# Summary' and fill in the template." > "$temp_file" 2>&1 &
 
     claude_pid=$!
-    set -m
 
     show_spinner $claude_pid "Generating PR description with Claude"
-    wait $claude_pid
+    wait $claude_pid 2>/dev/null
+    local claude_exit_code=$?
+    set -m
 
-    # Clear the trap once Claude finishes normally
-    trap - INT
-  }
+    # Check if we were interrupted - if so, just return silently
+    if [ "$interrupted" = true ]; then
+      return 1
+    fi
 
-  find_current_pr() {
-    pr_number=$(gh pr view --json number --jq '.number' 2>/dev/null)
-    if [ -z "$pr_number" ]; then
-      echo "Error: No PR found for current branch '$current_branch'"
-      echo "Make sure you have a PR open for this branch"
-      rm "$temp_file"
+    # Validate Claude output
+    if [ "$claude_exit_code" -ne 0 ] || [ ! -s "$temp_file" ]; then
+      echo "❌ Claude failed to generate description or produced empty output"
+      if [ -s "$temp_file" ]; then
+        echo "Claude error output:"
+        head -5 "$temp_file"
+      fi
+      return 1
+    fi
+
+    # Check if output looks reasonable (has some content)
+    local content_lines=$(grep -v '^[[:space:]]*$' "$temp_file" | wc -l)
+    if [ "$content_lines" -lt 3 ]; then
+      echo "❌ Claude output appears too short or invalid"
+      echo "Generated content:"
+      cat "$temp_file"
       return 1
     fi
   }
 
+  find_current_pr() {
+    if [ "$interrupted" = true ]; then
+      return 1
+    fi
+
+    if ! pr_info=$(gh pr view --json number,state --jq '{number: .number, state: .state}' 2>/dev/null) || [ -z "$pr_info" ]; then
+      echo "Error: No PR found for current branch '$current_branch'"
+      echo "Make sure you have a PR open for this branch"
+      return 1
+    fi
+
+    pr_number=$(echo "$pr_info" | jq -r '.number')
+    local pr_state=$(echo "$pr_info" | jq -r '.state')
+
+    if [ "$pr_state" = "MERGED" ]; then
+      echo "❌ PR #$pr_number has already been merged"
+      echo "Cannot modify description of merged PR to preserve history"
+      return 1
+    fi
+
+    if [ "$pr_state" = "CLOSED" ]; then
+      echo "⚠️  Warning: PR #$pr_number is closed but not merged"
+      echo "Proceeding anyway - you can still edit closed PR descriptions"
+    fi
+  }
+
   review_description_in_editor() {
+    if [ "$interrupted" = true ]; then
+      return 1
+    fi
+
     echo "Opening generated description in editor for review..."
 
     local temp_with_comments=$(mktemp)
@@ -95,13 +180,37 @@ pr-autofill-description() {
     cat "$temp_file" >> "$temp_with_comments"
     mv "$temp_with_comments" "$temp_file"
 
-    local mod_time_before=$(stat -f %m "$temp_file")
+    # Platform-compatible file modification time check
+    local mod_time_before
+    if command -v stat >/dev/null; then
+      if stat -f %m "$temp_file" >/dev/null 2>&1; then
+        # BSD/macOS stat
+        mod_time_before=$(stat -f %m "$temp_file")
+      elif stat -c %Y "$temp_file" >/dev/null 2>&1; then
+        # GNU/Linux stat
+        mod_time_before=$(stat -c %Y "$temp_file")
+      else
+        echo "❌ Error: stat command not compatible with this system"
+        echo "Please report this issue with your OS details"
+        return 1
+      fi
+    else
+      echo "❌ Error: stat command not found"
+      echo "This script requires the stat command to detect file changes"
+      return 1
+    fi
+
     ${EDITOR:-vim} "$temp_file"
-    local mod_time_after=$(stat -f %m "$temp_file")
+
+    local mod_time_after
+    if stat -f %m "$temp_file" >/dev/null 2>&1; then
+      mod_time_after=$(stat -f %m "$temp_file")
+    else
+      mod_time_after=$(stat -c %Y "$temp_file")
+    fi
 
     if [ "$mod_time_before" = "$mod_time_after" ]; then
       echo "No changes saved. Cancelling PR update."
-      rm "$temp_file"
       return 1
     fi
 
@@ -110,28 +219,37 @@ pr-autofill-description() {
   }
 
   update_pr_description() {
-    echo "Updating PR #$pr_number description..."
-    gh pr edit "$pr_number" --body-file "$temp_file"
+    if [ "$interrupted" = true ]; then
+      return 1
+    fi
 
-    if [ $? -eq 0 ]; then
-      echo "✅ Successfully updated PR #$pr_number description"
-      echo "🔗 View PR: $(gh pr view --json url --jq '.url')"
-    else
+    echo "Updating PR #$pr_number description..."
+
+    if ! gh pr edit "$pr_number" --body-file "$temp_file" 2>/dev/null; then
       echo "❌ Failed to update PR description"
       echo "Generated description saved to: $temp_file"
       return 1
     fi
 
-    rm "$temp_file"
+    echo "✅ Successfully updated PR #$pr_number description"
+    if ! pr_url=$(gh pr view --json url --jq '.url' 2>/dev/null); then
+      echo "PR updated successfully but could not retrieve URL"
+    else
+      echo "🔗 View PR: $pr_url"
+    fi
   }
 
   # Main execution flow
+  check_dependencies || return 1
   validate_git_environment || return 1
   determine_merge_target || return 1
 
   # Count words in the diff
-  local diff_content=$(git diff "$merge_target"...HEAD)
-  local word_count=$(echo "$diff_content" | wc -w | xargs)
+  if ! diff_content=$(git diff "$merge_target"...HEAD 2>/dev/null); then
+    echo "❌ Error: Could not generate git diff between '$merge_target' and '$current_branch'"
+    return 1
+  fi
+  word_count=$(echo "$diff_content" | wc -w | xargs)
 
   echo "Analyzing changes on branch '$current_branch' vs '$merge_target'... $word_count words/tokens changed."
 
@@ -145,8 +263,24 @@ pr-autofill-description() {
     return 1
   fi
 
-  generate_description_with_claude
+  # Check for existing PR before running Claude
   find_current_pr || return 1
+
+  # Check if interrupted after finding PR
+  if [ "$interrupted" = true ]; then
+    return 1
+  fi
+
+  # Create temporary file for the PR description
+  temp_file=$(mktemp)
+
+  generate_description_with_claude || return 1
+
+  # Check if interrupted after Claude
+  if [ "$interrupted" = true ]; then
+    return 1
+  fi
+
   review_description_in_editor || return 0
   update_pr_description
 }


### PR DESCRIPTION
# Summary

This PR makes the `pr-autofill-description` function more robust with better error handling, interrupt support, and cross-platform compatibility. I added proper cleanup on interrupts, better dependency checking, and made the stat command work on both macOS and Linux systems.

## Changes

- Added comprehensive dependency checking for git, gh, claude, and jq at startup
- Implemented proper interrupt handling (Ctrl+C) that cleans up background processes and temp files
- Made the function work on both macOS and Linux by detecting the right stat command syntax
- Added validation for PR state - won't let you edit merged PRs and warns about closed ones
- Improved error handling throughout - checks if commands succeed before proceeding
- Fixed the order of operations to check for a PR before running Claude (saves time if no PR exists)
- Added local variable declarations to avoid polluting the shell environment

## Commit History

### reorg autofiller, add trapping

Added interrupt handling and reorganized the flow to be more robust with better cleanup and error checking
