### PR TITLE
add splitter function and x/spl aliases

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -122,6 +122,10 @@ alias r9="sed -n '9p'"
 alias c="pbcopy"
 alias p="pbpaste"
 
+# execute piped command in current shell context
+alias x='while read cmd; do eval "$cmd"; done'
+alias spl='splitter'
+
 ########################
 #  Better tools        #
 ########################

--- a/functions/splitter.sh
+++ b/functions/splitter.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+splitter() {
+  local delimiter="$1"
+  local input
+  read -r input
+
+  if [[ -z "$delimiter" ]]; then
+    local non_alnum
+    non_alnum=$(printf '%s' "$input" | tr -d '[:alnum:]' | fold -w1 | sort -u | tr -d '\n')
+
+    if [[ ${#non_alnum} -eq 0 ]]; then
+      echo "$input"
+      return 0
+    elif [[ ${#non_alnum} -eq 1 ]]; then
+      delimiter="$non_alnum"
+    else
+      echo "Error: multiple delimiters found. Try one of:"
+      for (( i=0; i<${#non_alnum}; i++ )); do
+        char="${non_alnum:$i:1}"
+        echo "echo \"$input\" | splitter '$char'"
+      done
+      return 1
+    fi
+  fi
+
+  printf '%s' "$input" | tr "$delimiter" ' '
+  echo
+}


### PR DESCRIPTION
## Summary
- `splitter`: splits strings by delimiter (auto-detects if single unique non-alnum char)
- `x` alias: execute piped command via eval  
- `spl` alias: shorthand for splitter

## Usage
```bash
echo "cool.shit" | splitter           # => cool shit
echo "cool.shit" | splitter ':'       # => cool.shit
echo "rickgorman/claude-usage" | spl | r2 | x  # run 2nd suggestion
```