### PR TITLE
2026 shell additions: cc, http, telegram, tree aliases

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -136,7 +136,7 @@ man() {
 ########################
 #  Claude              #
 ########################
-alias cc="claude"
+alias ccc="cc --continue"
 
 ########################
 #  Project Setup       #

--- a/functions/cc.sh
+++ b/functions/cc.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+
+cc() {
+  for arg in "$@"; do
+    if [[ "$arg" == "--list-sessions" ]]; then
+      _cc_list_sessions
+      return $?
+    fi
+  done
+
+  local yolo_bin="${HOME}/work/claude-yolo/bin/claude-yolo"
+  if [[ -x "$yolo_bin" ]]; then
+    "$yolo_bin" "$@"
+  else
+    claude "$@"
+  fi
+}
+
+_cc_list_sessions() {
+  local projects_dir="${HOME}/.claude/projects"
+
+  if [[ ! -d "$projects_dir" ]]; then
+    echo "No sessions found (${projects_dir} does not exist)"
+    return 1
+  fi
+
+  local -a sorted_files=()
+  while IFS= read -r f; do
+    sorted_files+=("$f")
+  done < <(
+    find "$projects_dir" -maxdepth 2 -name "*.jsonl" -type f -print0 \
+      | xargs -0 stat -f "%m %N" 2>/dev/null \
+      | sort -rn \
+      | head -20 \
+      | sed 's/^[0-9]* //'
+  )
+
+  if [[ ${#sorted_files[@]} -eq 0 ]]; then
+    echo "No sessions found"
+    return 0
+  fi
+
+  local cols
+  cols=$(tput cols 2>/dev/null || echo 120)
+
+  # Separator line spanning terminal width
+  local sep
+  sep=$(python3 -c "print('─' * $cols)")
+
+  local count=0
+  for f in "${sorted_files[@]}"; do
+    [[ $count -ge 10 ]] && break
+
+    local uuid='' mtime='' cwd='' branch='' first_text='' repo='' linecount=''
+
+    uuid=$(basename "$f" .jsonl)
+    mtime=$(stat -f "%Sm" -t "%b %d %H:%M" "$f" 2>/dev/null || echo "?")
+
+    # Use Python to extract cwd, gitBranch, and first user message in one pass.
+    # Scans up to 100 lines because newer Claude Code files start with a
+    # file-history-snapshot record on line 1 that has no cwd — the real
+    # session metadata begins on line 2.  Outputs exactly three lines:
+    # cwd, gitBranch, first_text (empty string if not found).
+    {
+      read -r cwd
+      read -r branch
+      read -r first_text
+    } < <(
+      head -100 "$f" | python3 -c "
+import json, re, sys
+
+cwd = ''
+branch = ''
+first_text = ''
+candidates = []
+
+for line in sys.stdin:
+    try:
+        d = json.loads(line)
+
+        # cwd and gitBranch are top-level keys on any non-snapshot line
+        if not cwd and 'cwd' in d:
+            cwd = d['cwd']
+            branch = d.get('gitBranch', '')
+
+        # Collect user message text, cleaned up
+        if d.get('type') == 'user' and 'message' in d:
+            c = d['message'].get('content', '')
+            text = ''
+            if isinstance(c, str) and c and not c.startswith('<'):
+                text = c
+            elif isinstance(c, list):
+                for block in c:
+                    if isinstance(block, dict) and block.get('type') == 'text':
+                        t = block.get('text', '')
+                        if t and not t.startswith('<'):
+                            text = t
+                            break
+
+            if text:
+                # Strip markdown heading markers (e.g. '# Title' -> 'Title')
+                text = re.sub(r'(?m)^#+\s+', '', text)
+                # Collapse all whitespace/newlines to single spaces
+                text = re.sub(r'\s+', ' ', text).strip()
+                candidates.append(text)
+                # Take it immediately if it's long enough to be meaningful
+                if len(text) >= 20:
+                    first_text = text
+                    break
+    except Exception:
+        pass
+
+# If nothing was long enough, fall back to the longest candidate found
+if not first_text and candidates:
+    first_text = max(candidates, key=len)
+
+print(cwd)
+print(branch)
+print(first_text)
+" 2>/dev/null
+    )
+
+    # Skip noise files (file-history-snapshot, queue-operation, etc.) with no cwd
+    [[ -z "$cwd" ]] && continue
+
+    repo=$(basename "$cwd")
+    linecount=$(wc -l < "$f" 2>/dev/null | tr -d ' ')
+
+    # Line 1: separator
+    echo "$sep"
+    # Line 2: date · repo · branch · linecount · hash
+    printf "%s  %-16s  %-18s  %5sL  %s\n" \
+      "$mtime" "$repo" "$branch" "$linecount" "$uuid"
+    # Line 3: preview text, indented, truncated to terminal width
+    printf "  %s\n" "${first_text:0:$((cols - 3))}"
+
+    ((count++))
+  done
+
+  echo "$sep"
+}

--- a/functions/telegram.sh
+++ b/functions/telegram.sh
@@ -3,9 +3,8 @@
 #   echo "Hello world" | telegram
 #   cat file.txt | telegram
 #
-# Requires ~/.env with:
-#   TELEGRAM_BOT_TOKEN=your_bot_token
-#   TELEGRAM_CHAT_ID=your_chat_id
+# Requires TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID — either set in the current
+# shell or in ~/.env (sourced automatically if the vars are not already present).
 
 telegram() {
   local env_file="$HOME/.env"
@@ -16,23 +15,10 @@ TELEGRAM_BOT_TOKEN=
 TELEGRAM_CHAT_ID=
 '
 
-  if [[ ! -f "$env_file" ]]; then
-    echo "Error: ~/.env file not found"
-    echo "$help_text"
-    echo "To get your bot token:"
-    echo "  1. Open Telegram and search for @BotFather"
-    echo "  2. Send /newbot and follow the prompts"
-    echo "  3. Copy the token provided"
-    echo "  https://t.me/BotFather"
-    echo ""
-    echo "To get your chat ID:"
-    echo "  1. Send any message to your bot"
-    echo "  2. Visit: https://api.telegram.org/bot<YOUR_BOT_TOKEN>/getUpdates"
-    echo "  3. Find your chat id in the response under result[].message.chat.id"
-    return 1
+  # Source ~/.env if the vars aren't already set in the current shell
+  if [[ -z "$TELEGRAM_BOT_TOKEN" || -z "$TELEGRAM_CHAT_ID" ]]; then
+    [[ -f "$env_file" ]] && source "$env_file"
   fi
-
-  source "$env_file"
 
   if [[ -z "$TELEGRAM_BOT_TOKEN" || -z "$TELEGRAM_CHAT_ID" ]]; then
     echo "Error: Missing TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID in ~/.env"


### PR DESCRIPTION
## Summary

**cc / ccc**
- `functions/cc.sh`: wraps `claude`/`claude-yolo`; adds `--list-sessions` to show recent Claude Code sessions in a 3-line format (separator, metadata, preview) sorted by mtime — uses Python to scan up to 100 lines per file, handles the `file-history-snapshot`-first JSONL format, strips markdown headers, falls back to longest message if first is too short
- `aliases.local`: replaces `alias cc="claude"` with `alias ccc="cc --continue"` now that `cc` is a function

**http**
- `functions/http.sh`: lookup HTTP status codes — `http` lists all, `http 40` filters by prefix

**telegram**
- `functions/telegram.sh`: pipe stdin to Telegram — reads `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` from `~/.env`

**misc**
- `zshrc.local`: add `~/.local/bin` to PATH, add `t1`/`t2`/`t3` tree aliases