### PR TITLE
Add cc function, http/telegram utils, and tree aliases

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -136,7 +136,7 @@ man() {
 ########################
 #  Claude              #
 ########################
-alias cc="claude"
+alias ccc="cc --continue"
 
 ########################
 #  Project Setup       #

--- a/functions/cc.sh
+++ b/functions/cc.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+
+cc() {
+  for arg in "$@"; do
+    if [[ "$arg" == "--list-sessions" ]]; then
+      _cc_list_sessions
+      return $?
+    fi
+  done
+
+  local yolo_bin="${HOME}/work/claude-yolo/bin/claude-yolo"
+  if [[ -x "$yolo_bin" ]]; then
+    "$yolo_bin" "$@"
+  else
+    claude "$@"
+  fi
+}
+
+_cc_list_sessions() {
+  local projects_dir="${HOME}/.claude/projects"
+
+  if [[ ! -d "$projects_dir" ]]; then
+    echo "No sessions found (${projects_dir} does not exist)"
+    return 1
+  fi
+
+  local -a sorted_files=()
+  while IFS= read -r f; do
+    sorted_files+=("$f")
+  done < <(
+    find "$projects_dir" -maxdepth 2 -name "*.jsonl" -type f -print0 \
+      | xargs -0 stat -f "%m %N" 2>/dev/null \
+      | sort -rn \
+      | head -20 \
+      | sed 's/^[0-9]* //'
+  )
+
+  if [[ ${#sorted_files[@]} -eq 0 ]]; then
+    echo "No sessions found"
+    return 0
+  fi
+
+  local cols
+  cols=$(tput cols 2>/dev/null || echo 120)
+
+  # Separator line spanning terminal width
+  local sep
+  sep=$(python3 -c "print('─' * $cols)")
+
+  local count=0
+  for f in "${sorted_files[@]}"; do
+    [[ $count -ge 10 ]] && break
+
+    local uuid='' mtime='' cwd='' branch='' first_text='' repo='' linecount=''
+
+    uuid=$(basename "$f" .jsonl)
+    mtime=$(stat -f "%Sm" -t "%b %d %H:%M" "$f" 2>/dev/null || echo "?")
+
+    # Use Python to extract cwd, gitBranch, and first user message in one pass.
+    # Scans up to 100 lines because newer Claude Code files start with a
+    # file-history-snapshot record on line 1 that has no cwd — the real
+    # session metadata begins on line 2.  Outputs exactly three lines:
+    # cwd, gitBranch, first_text (empty string if not found).
+    {
+      read -r cwd
+      read -r branch
+      read -r first_text
+    } < <(
+      head -100 "$f" | python3 -c "
+import json, re, sys
+
+cwd = ''
+branch = ''
+first_text = ''
+candidates = []
+
+for line in sys.stdin:
+    try:
+        d = json.loads(line)
+
+        # cwd and gitBranch are top-level keys on any non-snapshot line
+        if not cwd and 'cwd' in d:
+            cwd = d['cwd']
+            branch = d.get('gitBranch', '')
+
+        # Collect user message text, cleaned up
+        if d.get('type') == 'user' and 'message' in d:
+            c = d['message'].get('content', '')
+            text = ''
+            if isinstance(c, str) and c and not c.startswith('<'):
+                text = c
+            elif isinstance(c, list):
+                for block in c:
+                    if isinstance(block, dict) and block.get('type') == 'text':
+                        t = block.get('text', '')
+                        if t and not t.startswith('<'):
+                            text = t
+                            break
+
+            if text:
+                # Strip markdown heading markers (e.g. '# Title' -> 'Title')
+                text = re.sub(r'(?m)^#+\s+', '', text)
+                # Collapse all whitespace/newlines to single spaces
+                text = re.sub(r'\s+', ' ', text).strip()
+                candidates.append(text)
+                # Take it immediately if it's long enough to be meaningful
+                if len(text) >= 20:
+                    first_text = text
+                    break
+    except Exception:
+        pass
+
+# If nothing was long enough, fall back to the longest candidate found
+if not first_text and candidates:
+    first_text = max(candidates, key=len)
+
+print(cwd)
+print(branch)
+print(first_text)
+" 2>/dev/null
+    )
+
+    # Skip noise files (file-history-snapshot, queue-operation, etc.) with no cwd
+    [[ -z "$cwd" ]] && continue
+
+    repo=$(basename "$cwd")
+    linecount=$(wc -l < "$f" 2>/dev/null | tr -d ' ')
+
+    # Line 1: separator
+    echo "$sep"
+    # Line 2: date · repo · branch · linecount · hash
+    printf "%s  %-16s  %-18s  %5sL  %s\n" \
+      "$mtime" "$repo" "$branch" "$linecount" "$uuid"
+    # Line 3: preview text, indented, truncated to terminal width
+    printf "  %s\n" "${first_text:0:$((cols - 3))}"
+
+    ((count++))
+  done
+
+  echo "$sep"
+}

--- a/functions/http.sh
+++ b/functions/http.sh
@@ -1,0 +1,76 @@
+# List HTTP status codes with optional filtering
+# Usage:
+#   http       - list all codes
+#   http 40    - list codes starting with 40
+#   http 401   - list codes starting with 401
+
+http() {
+  local codes="100 Continue
+101 Switching Protocols
+102 Processing
+103 Early Hints
+200 OK
+201 Created
+202 Accepted
+203 Non-Authoritative Information
+204 No Content
+205 Reset Content
+206 Partial Content
+207 Multi-Status
+208 Already Reported
+226 IM Used
+300 Multiple Choices
+301 Moved Permanently
+302 Found
+303 See Other
+304 Not Modified
+305 Use Proxy
+307 Temporary Redirect
+308 Permanent Redirect
+400 Bad Request
+401 Unauthorized
+402 Payment Required
+403 Forbidden
+404 Not Found
+405 Method Not Allowed
+406 Not Acceptable
+407 Proxy Authentication Required
+408 Request Timeout
+409 Conflict
+410 Gone
+411 Length Required
+412 Precondition Failed
+413 Payload Too Large
+414 URI Too Long
+415 Unsupported Media Type
+416 Range Not Satisfiable
+417 Expectation Failed
+418 I'm a teapot
+421 Misdirected Request
+422 Unprocessable Entity
+423 Locked
+424 Failed Dependency
+425 Too Early
+426 Upgrade Required
+428 Precondition Required
+429 Too Many Requests
+431 Request Header Fields Too Large
+451 Unavailable For Legal Reasons
+500 Internal Server Error
+501 Not Implemented
+502 Bad Gateway
+503 Service Unavailable
+504 Gateway Timeout
+505 HTTP Version Not Supported
+506 Variant Also Negotiates
+507 Insufficient Storage
+508 Loop Detected
+510 Not Extended
+511 Network Authentication Required"
+
+  if [[ -z "$1" ]]; then
+    echo "$codes"
+  else
+    echo "$codes" | grep "^$1"
+  fi
+}

--- a/functions/telegram.sh
+++ b/functions/telegram.sh
@@ -3,9 +3,8 @@
 #   echo "Hello world" | telegram
 #   cat file.txt | telegram
 #
-# Requires ~/.env with:
-#   TELEGRAM_BOT_TOKEN=your_bot_token
-#   TELEGRAM_CHAT_ID=your_chat_id
+# Requires TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID — either set in the current
+# shell or in ~/.env (sourced automatically if the vars are not already present).
 
 telegram() {
   local env_file="$HOME/.env"
@@ -16,23 +15,10 @@ TELEGRAM_BOT_TOKEN=
 TELEGRAM_CHAT_ID=
 '
 
-  if [[ ! -f "$env_file" ]]; then
-    echo "Error: ~/.env file not found"
-    echo "$help_text"
-    echo "To get your bot token:"
-    echo "  1. Open Telegram and search for @BotFather"
-    echo "  2. Send /newbot and follow the prompts"
-    echo "  3. Copy the token provided"
-    echo "  https://t.me/BotFather"
-    echo ""
-    echo "To get your chat ID:"
-    echo "  1. Send any message to your bot"
-    echo "  2. Visit: https://api.telegram.org/bot<YOUR_BOT_TOKEN>/getUpdates"
-    echo "  3. Find your chat id in the response under result[].message.chat.id"
-    return 1
+  # Source ~/.env if the vars aren't already set in the current shell
+  if [[ -z "$TELEGRAM_BOT_TOKEN" || -z "$TELEGRAM_CHAT_ID" ]]; then
+    [[ -f "$env_file" ]] && source "$env_file"
   fi
-
-  source "$env_file"
 
   if [[ -z "$TELEGRAM_BOT_TOKEN" || -z "$TELEGRAM_CHAT_ID" ]]; then
     echo "Error: Missing TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID in ~/.env"

--- a/functions/telegram.sh
+++ b/functions/telegram.sh
@@ -1,0 +1,75 @@
+# Send a message to Telegram via stdin
+# Usage:
+#   echo "Hello world" | telegram
+#   cat file.txt | telegram
+#
+# Requires ~/.env with:
+#   TELEGRAM_BOT_TOKEN=your_bot_token
+#   TELEGRAM_CHAT_ID=your_chat_id
+
+telegram() {
+  local env_file="$HOME/.env"
+  local help_text='
+Add the following to your ~/.env file:
+
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=
+'
+
+  if [[ ! -f "$env_file" ]]; then
+    echo "Error: ~/.env file not found"
+    echo "$help_text"
+    echo "To get your bot token:"
+    echo "  1. Open Telegram and search for @BotFather"
+    echo "  2. Send /newbot and follow the prompts"
+    echo "  3. Copy the token provided"
+    echo "  https://t.me/BotFather"
+    echo ""
+    echo "To get your chat ID:"
+    echo "  1. Send any message to your bot"
+    echo "  2. Visit: https://api.telegram.org/bot<YOUR_BOT_TOKEN>/getUpdates"
+    echo "  3. Find your chat id in the response under result[].message.chat.id"
+    return 1
+  fi
+
+  source "$env_file"
+
+  if [[ -z "$TELEGRAM_BOT_TOKEN" || -z "$TELEGRAM_CHAT_ID" ]]; then
+    echo "Error: Missing TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID in ~/.env"
+    echo "$help_text"
+    echo "To get your bot token:"
+    echo "  1. Open Telegram and search for @BotFather"
+    echo "  2. Send /newbot and follow the prompts"
+    echo "  3. Copy the token provided"
+    echo "  https://t.me/BotFather"
+    echo ""
+    echo "To get your chat ID:"
+    echo "  1. Send any message to your bot"
+    echo "  2. Visit: https://api.telegram.org/bot<YOUR_BOT_TOKEN>/getUpdates"
+    echo "  3. Find your chat id in the response under result[].message.chat.id"
+    return 1
+  fi
+
+  local message
+  message=$(cat)
+
+  if [[ -z "$message" ]]; then
+    echo "Error: No message provided via stdin"
+    echo "Usage: echo 'your message' | telegram"
+    return 1
+  fi
+
+  local response
+  response=$(curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+    -H "Content-Type: application/json" \
+    -d "$(jq -n --arg chat_id "$TELEGRAM_CHAT_ID" --arg text "$message" \
+      '{chat_id: $chat_id, text: $text}')")
+
+  echo "$response"
+
+  if echo "$response" | jq -e '.ok == true' > /dev/null 2>&1; then
+    return 0
+  else
+    return 1
+  fi
+}

--- a/zshrc.local
+++ b/zshrc.local
@@ -50,6 +50,7 @@ eval $(thefuck --alias)
 # look for commands in these places
 export PATH="/Applications/Postgres.app/Contents/Versions/latest/bin:$PATH"
 export PATH="$HOME/.bin:$PATH"
+export PATH="$HOME/.local/bin:$PATH"
 
 # make vim the default text editor
 export EDITOR="vim"
@@ -67,6 +68,14 @@ export NVM_DIR="$HOME/.nvm"
 
 # default to main, allow overrides via dotenv
 export MASTER_BRANCH_NAME="main"
+
+###############
+### aliases ###
+###############
+
+alias t1='tree -L 1'
+alias t2='tree -L 2'
+alias t3='tree -L 3'
 
 #############
 ### other ###


### PR DESCRIPTION
## Summary

- Replace `alias cc="claude"` with a `cc()` function that routes through `claude-yolo` when available, adds `--list-sessions` support, and adds `ccc` alias for `cc --continue`
- Add `http` function for quick HTTP status code lookup/filtering
- Add `telegram` function to send messages via stdin using a Telegram bot
- Add `t1`/`t2`/`t3` tree depth aliases and `~/.local/bin` to PATH
- Fix telegram to only source `~/.env` when env vars aren't already set

## Test plan

- [ ] `cc` invokes `claude-yolo` when the binary exists, falls back to `claude`
- [ ] `cc --list-sessions` shows recent Claude sessions
- [ ] `ccc` continues the last session
- [ ] `http`, `http 40`, `http 404` filter correctly
- [ ] `echo "test" | telegram` sends a message (with valid creds)
- [ ] `t1`/`t2`/`t3` produce expected tree output