### PR TITLE
skip chpwd ls inside claude code sessions

### DIFF
--- a/zsh/configs/post/chpwd
+++ b/zsh/configs/post/chpwd
@@ -1,4 +1,5 @@
-# list a directory after cd-ing into it
+# list a directory after cd-ing into it (skip inside Claude Code sessions)
 function chpwd {
+  [[ -n "$CLAUDECODE" ]] && return
   ls
 }


### PR DESCRIPTION
## Summary

The `chpwd` hook lists directory contents after every `cd`, which is great interactively but clutters output when Claude Code runs shell commands. This guards the hook so it bails out inside Claude sessions.

## Changes

- `zsh/configs/post/chpwd`: early return when `$CLAUDECODE` is set (Claude Code exports `CLAUDECODE=1` in every shell it spawns). Interactive terminals unaffected.

## Commit History

- skip chpwd ls inside claude code sessions